### PR TITLE
Update to harmony-api 2 schema

### DIFF
--- a/harmony-switches.yaml
+++ b/harmony-switches.yaml
@@ -1,31 +1,31 @@
 - platform: mqtt
   name: "Media Room TV"
-  state_topic: "harmony-api/state"
-  command_topic: "harmony-api/activities/watch-tv/command"
+  state_topic: "harmony-api/hubs/harmony-hub/state"
+  command_topic: "harmony-api/hubs/harmony-hub/activities/watch-tv/command"
   qos: 0
   optimistic: true
   payload_on: "on"
   payload_off: "off"
 - platform: mqtt
   name: "DirecTV"
-  state_topic: "harmony-api/activities/watch-tv/state"
-  command_topic: "harmony-api/activities/watch-tv/command"
+  state_topic: "harmony-api/hubs/harmony-hub/activities/watch-tv/state"
+  command_topic: "harmony-api/hubs/harmony-hub/activities/watch-tv/command"
   qos: 0
   optimistic: true
   payload_on: "on"
   payload_off: "off"
 - platform: mqtt
   name: "Apple TV"
-  state_topic: "harmony-api/activities/watch-apple-tv/state"
-  command_topic: "harmony-api/activities/watch-apple-tv/command"
+  state_topic: "harmony-api/hubs/harmony-hub/activities/watch-apple-tv/state"
+  command_topic: "harmony-api/hubs/harmony-hub/activities/watch-apple-tv/command"
   qos: 0
   optimistic: true
   payload_on: "on"
   payload_off: "off"
 - platform: mqtt
   name: "Media Room Music"
-  state_topic: "harmony-api/activities/listen-to-music/state"
-  command_topic: "harmony-api/activities/listen-to-music/command"
+  state_topic: "harmony-api/hubs/harmony-hub/activities/listen-to-music/state"
+  command_topic: "harmony-api/hubs/harmony-hub/activities/listen-to-music/command"
   qos: 0
   optimistic: true
   payload_on: "on"


### PR DESCRIPTION
harmony-api introduced a new namespace to support multiple hubs, but I never updated.

Fixes https://github.com/technicalpickles/picklehome/issues/1