### PR TITLE
Add Rachio

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -77,3 +77,10 @@ sun:
 switch harmony hub: !include harmony-switches.yaml
 switch house modes: !include house-modes.yaml
 vera: !include vera.yaml
+switch rachio: !include rachio.yaml
+
+panel_iframe:
+  rachio:
+    title: Rachio
+    url: "https://app.rach.io"
+    icon: mdi:water-pump

--- a/groups.yaml
+++ b/groups.yaml
@@ -279,6 +279,21 @@ cottage:
     - group.cottage_network
     - group.cottage_outside_lights
 
+irrigation:
+  name: Irrigation
+  icon: mdi:water-pump
+  entities:
+    - switch.back_yard_left
+    - switch.back_yard_right
+
+back_yard:
+  name: Back Yard
+  view: yes
+  entities:
+    - group.irrigation
+    - light.cottage_back_yard # FIXME this doesn't seem to be reachable, but can control from hue group?!
+    - switch.porch_mode
+
 speedtest:
   name: Speedtest
   entities:

--- a/rachio.yaml
+++ b/rachio.yaml
@@ -1,0 +1,2 @@
+- platform: rachio
+  access_token: !secret rachio_access_token

--- a/secrets.yaml.example
+++ b/secrets.yaml.example
@@ -15,3 +15,4 @@ sleepiq_password: bar
 vera_controller_url: http://192.168.1.161:3480/
 nest_client_id: 1234
 nest_client_secret: 1234
+rachio_access_token: secret-secret-secret


### PR DESCRIPTION
Follows the instructions over at https://home-assistant.io/components/switch.rachio/ , including making a group for them, and adding the panel iframe.