### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,5 @@ before_install:
   - docker pull boiyaa/yamllint
 
 script:
-  - "docker run -it --rm -v $(pwd):/workdir boiyaa/yamllint -d '{extends: relaxed, rules: {line-length: disable}}' ."
   - "cp secrets.yaml.example secrets.yaml"
-  - "docker run -v $(pwd):/config homeassistant/home-assistant python -m homeassistant --config /config --script check_config"
+  - "script/test"

--- a/script/test
+++ b/script/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker run -it --rm -v $(pwd):/workdir boiyaa/yamllint -d '{extends: relaxed, rules: {line-length: disable}}' .
+docker run -v $(pwd):/config homeassistant/home-assistant python -m homeassistant --config /config --script check_config

--- a/secrets.yaml.example
+++ b/secrets.yaml.example
@@ -17,7 +17,7 @@ vera_portal_url: http://192.168.1.161
 nest_client_id: 1234
 nest_client_secret: 1234
 rachio_access_token: secret-secret-secret
-cloud_mode: ""
+cloud_mode: "development"
 cloud_cognito_client_id: ""
 cloud_user_pool_id: ""
 cloud_region: ""


### PR DESCRIPTION
master was failing for awhile. Make it a little easier to test locally.

The main thing that won't be the same as Travis is the secrets.yaml.example will be used, rather than the local one. I think it _should_ be possible to mount the secrets.yaml.example as the secrets.yaml in a new docker container, without messing with the 'production secrets.yaml

