### PR TITLE
Add deck lighting to exterior lighting

### DIFF
--- a/groups.yaml
+++ b/groups.yaml
@@ -64,6 +64,7 @@ exterior_lights:
     - group.front_door_lights
     - group.kitchen_door_lights
     - group.cottage_outside_lights
+    - light.deck
 
 exterior_christmas_lights:
   name: Exterior Christmas Lights


### PR DESCRIPTION
This was a new light. Without this, it doesn't automatically turn on at sunset and off at sunrise.