### PR TITLE
Enable modern javascript

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -18,6 +18,7 @@ homeassistant:
 
 # Enables the frontend
 frontend:
+  javascript_version: latest
 
 # Enables configuration UI
 config:


### PR DESCRIPTION
this was introduced in 0.58: https://home-assistant.io/blog/2017/11/18/release-58/#frontend-improvements-continue