### PR TITLE
Flesh out harmony hub scenes

### DIFF
--- a/alexa.yaml
+++ b/alexa.yaml
@@ -10,6 +10,12 @@ filter:
     - switch.porch_mode
     - switch.christmas_tree_19
     - switch.nursery_night_light_22
+    - switch.media_room_tv
+    - switch.directv
+    - switch.apple_tv
+    - switch.smart_tv
+    - switch.super_nintendo
+
   # and exclude lights we don't need individual control over
   exclude_entities:
     - light.front_door_1

--- a/customize.yaml
+++ b/customize.yaml
@@ -16,3 +16,19 @@ light.kitchen:
   friendly_name: Kitchen Lights
 light.kitchen_door:
   friendly_name: Kitchen Door Lights
+
+switch.media_room_tv:
+  alexa_name: "Media Room TV"
+  alexa_display_categories: ACTIVITY_TRIGGER
+switch.directv:
+  alexa_name: "Direct TV"
+  alexa_display_categories: ACTIVITY_TRIGGER
+switch.apple_tv:
+  alexa_name: "Apple TV"
+  alexa_display_categories: ACTIVITY_TRIGGER
+Switch.smart_tv:
+  alexa_name: "Smart TV"
+  alexa_display_categories: ACTIVITY_TRIGGER
+Switch.smart_tv:
+  alexa_name: "Super Nintendo"
+  alexa_display_categories: ACTIVITY_TRIGGER

--- a/groups.yaml
+++ b/groups.yaml
@@ -194,6 +194,7 @@ media_room_tv:
     - switch.media_room_tv
     - switch.directv
     - switch.apple_tv
+    - switch.smart_tv
     - switch.media_room_music
 
 media_room_lights:

--- a/harmony-switches.yaml
+++ b/harmony-switches.yaml
@@ -23,6 +23,22 @@
   payload_on: "on"
   payload_off: "off"
 - platform: mqtt
+  name: "Smart TV"
+  state_topic: "harmony-api/hubs/harmony-hub/activities/watch-smart-tv/state"
+  command_topic: "harmony-api/hubs/harmony-hub/activities/watch-smart-tv/command"
+  qos: 0
+  optimistic: true
+  payload_on: "on"
+  payload_off: "off"
+- platform: mqtt
+  name: "Super Nintendo"
+  state_topic: "harmony-api/hubs/harmony-hub/activities/play-super-nintendo/state"
+  command_topic: "harmony-api/hubs/harmony-hub/activities/play-super-nintendo/command"
+  qos: 0
+  optimistic: true
+  payload_on: "on"
+  payload_off: "off"
+- platform: mqtt
   name: "Media Room Music"
   state_topic: "harmony-api/hubs/harmony-hub/activities/listen-to-music/state"
   command_topic: "harmony-api/hubs/harmony-hub/activities/listen-to-music/command"


### PR DESCRIPTION
- expose the switches as activities, so they show up as scenes in Alexa
- add activities that have been added since the lat time I worked on this

Part of https://github.com/technicalpickles/picklehome/issues/8