### PR TITLE
Guest mode

### DIFF
--- a/alexa.yaml
+++ b/alexa.yaml
@@ -5,6 +5,7 @@ filter:
     - lock
   # add in things we care to control
   include_entities:
+    - input_boolean.guest_mode
     - switch.bath_mode
     - switch.fireplace
     - switch.porch_mode

--- a/groups.yaml
+++ b/groups.yaml
@@ -324,7 +324,7 @@ cottage:
     - group.cottage_outside_lights
     - switch.cottage_smart_plug_20
     - group.cottage_locks
-    - switch.guest_mode
+    - input_boolean.guest_mode
 
 irrigation:
   name: Irrigation

--- a/groups.yaml
+++ b/groups.yaml
@@ -3,6 +3,7 @@ dashboard:
   entities:
     - group.family
     - input_select.house_mode
+    - input_boolean.guest_mode
     - lock.kitchen_front_door_11
     - lock.kitchen_side_door_13
     - climate.home
@@ -309,6 +310,7 @@ cottage_network:
     - sensor.airport_express_online
 
 cottage_locks:
+  name: "Locks"
   entities:
     - lock.cottage_back_door_15
     - lock.cottage_front_door_16
@@ -322,6 +324,7 @@ cottage:
     - group.cottage_outside_lights
     - switch.cottage_smart_plug_20
     - group.cottage_locks
+    - input_boolean.guest_mode
 
 irrigation:
   name: Irrigation

--- a/groups.yaml
+++ b/groups.yaml
@@ -3,13 +3,13 @@ dashboard:
   entities:
     - group.family
     - input_select.house_mode
-    - input_boolean.guest_mode
     - lock.kitchen_front_door_11
     - lock.kitchen_side_door_13
     - climate.home
     - group.interior_temperature
     - group.weather
     - script.sunset
+    - switch.guest_mode
     - switch.bath_mode
     - switch.porch_mode
     - scene.sunrise
@@ -324,7 +324,7 @@ cottage:
     - group.cottage_outside_lights
     - switch.cottage_smart_plug_20
     - group.cottage_locks
-    - input_boolean.guest_mode
+    - switch.guest_mode
 
 irrigation:
   name: Irrigation

--- a/packages/guest_mode.yaml
+++ b/packages/guest_mode.yaml
@@ -1,24 +1,13 @@
-input_boolean:
-  guest_mode:
-    name: "Guest Mode"
-
-
-automation:
-  - alias: Guest Mode Off
-    trigger:
-      platform: state
-      entity_id: input_boolean.guest_mode
-      to: 'off'
-    action:
-      service: script.guest_mode_off
-
-  - alias: Guest Mode On
-    trigger:
-      platform: state
-      entity_id: input_boolean.guest_mode
-      to: 'on'
-    action:
-      service: script.guest_mode_on
+switch:
+- platform: template
+  switches:
+    guest_mode:
+      friendly_name: Guest Mode
+      value_template: "{{ not (is_state_attr('climate.cottage', 'target_temp_low', 50) and is_state_attr('climate.cottage', 'target_temp_high', 78) and is_state_attr('climate.cottage', 'operation_mode', 'auto')) }}"
+      turn_on:
+        service: script.guest_mode_on
+      turn_off:
+        service: script.guest_mode_off
 
 script:
   guest_mode_off:

--- a/packages/guest_mode.yaml
+++ b/packages/guest_mode.yaml
@@ -1,15 +1,32 @@
-switch:
-- platform: template
-  switches:
-    guest_mode:
-      friendly_name: Guest Mode
-      value_template: "{{ not (is_state_attr('climate.cottage', 'target_temp_low', 50) and is_state_attr('climate.cottage', 'target_temp_high', 78) and is_state_attr('climate.cottage', 'operation_mode', 'auto')) }}"
-      turn_on:
-        service: script.guest_mode_on
-      turn_off:
-        service: script.guest_mode_off
+input_boolean:
+  guest_mode:
+   name: Guest Mode
+
+automation:
+  - name: Guest Mode Off
+    trigger:
+      platform: state
+      entity_id: input_boolean.guest_mode
+      to: 'off'
+    action:
+      service: script.guest_mode_off
+  - name: Guest Mode On
+    trigger:
+      platform: state
+      entity_id: input_boolean.guest_mode
+      to: 'on'
+    action:
+      service: script.guest_mode_on
 
 script:
+  restore_guest_mode_climate:
+    sequence:
+      - service_template: "
+	  {% if has_state('input_boolean.guest_mode', 'on') %}
+            script.guest_mode_on
+          {% else %}
+            script.guest_mode_off
+          {% endif %}"
   guest_mode_off:
     sequence:
       - service: climate.set_temperature

--- a/packages/guest_mode.yaml
+++ b/packages/guest_mode.yaml
@@ -3,14 +3,14 @@ input_boolean:
    name: Guest Mode
 
 automation:
-  - name: Guest Mode Off
+  - alias: Guest Mode Off
     trigger:
       platform: state
       entity_id: input_boolean.guest_mode
       to: 'off'
     action:
       service: script.guest_mode_off
-  - name: Guest Mode On
+  - alias: Guest Mode On
     trigger:
       platform: state
       entity_id: input_boolean.guest_mode
@@ -22,13 +22,17 @@ script:
   restore_guest_mode_climate:
     sequence:
       - service_template: "
-	  {% if has_state('input_boolean.guest_mode', 'on') %}
+	  {% if is_state('input_boolean.guest_mode', 'on') %}
             script.guest_mode_on
           {% else %}
             script.guest_mode_off
           {% endif %}"
   guest_mode_off:
     sequence:
+      - service: climate.set_operation_mode
+        entity_id: climate.cottage
+        data:
+          operation_mode: 'auto'
       - service: climate.set_temperature
         entity_id: climate.cottage
         data:
@@ -38,5 +42,9 @@ script:
 
   guest_mode_on:
     sequence:
+      - service: climate.set_operation_mode
+        entity_id: climate.cottage
+        data:
+          operation_mode: 'auto'
       - service: climate.ecobee_resume_program
         entity_id: climate.cottage

--- a/packages/guest_mode.yaml
+++ b/packages/guest_mode.yaml
@@ -1,0 +1,36 @@
+input_boolean:
+  guest_mode:
+    name: "Guest Mode"
+
+
+automation:
+  - alias: Guest Mode Off
+    trigger:
+      platform: state
+      entity_id: input_boolean.guest_mode
+      to: 'off'
+    action:
+      service: script.guest_mode_off
+
+  - alias: Guest Mode On
+    trigger:
+      platform: state
+      entity_id: input_boolean.guest_mode
+      to: 'on'
+    action:
+      service: script.guest_mode_on
+
+script:
+  guest_mode_off:
+    sequence:
+      - service: climate.set_temperature
+        entity_id: climate.cottage
+        data:
+          operation_mode: auto
+          target_temp_low: 50
+          target_temp_high: 78
+
+  guest_mode_on:
+    sequence:
+      - service: climate.ecobee_resume_program
+        entity_id: climate.cottage

--- a/packages/porch_mode.yaml
+++ b/packages/porch_mode.yaml
@@ -5,11 +5,9 @@ switch:
       friendly_name: Porch Mode
       value_template: "{{ is_state('climate.cottage', 'off') }}"
       turn_on:
-        service: script.turn_on
-        entity_id: script.porch_mode_on
+        service: script.porch_mode_on
       turn_off:
-        service: script.turn_on
-        entity_id: script.porch_mode_off
+        service: script.porch_mode_off
 
 script:
   porch_mode_on:
@@ -35,9 +33,6 @@ script:
 
   porch_mode_off:
     sequence:
-      - service: climate.set_operation_mode
-        entity_id: climate.cottage
-        data:
-          operation_mode: 'auto'
+      - service: script.restore_guest_mode_climate
       - service: script.turn_off
         entity_id: script.porch_mode_auto_off


### PR DESCRIPTION
Work towards https://github.com/technicalpickles/picklehome/issues/32

I started with an `input_boolean` to control it, but I don't like how you need to add 2 automations, one for on and off.

I tried a `switch.template` instead, which was nicer. The downside is that you have to use something for the `value_template`. I tried using the `climate.cottage` target temp and mode, but realized that `porch_mode` would interfere with it. If you turned on porch mode, having the guest mode `value_template` based on the climate would turn off, and you wouldn't have a way to know that it needed to be reset.

I ended up going back to `input_boolean` after that. I also added a script to restore the guest mode's climate, so porch mode could call that.