### PR TITLE
Southern comfort

### DIFF
--- a/groups.yaml
+++ b/groups.yaml
@@ -39,7 +39,8 @@ interior_temperature:
     - sensor.nursery_temperature
     - sensor.office__josh_temperature
     - sensor.office__tracy_temperature
-    - script.climate_its_ok_out
+    - script.apply_southern_comfort
+    - script.climate_its_ok_outside
     - script.climate_its_hot_outside
     - script.climate_its_cold_outside
 

--- a/groups.yaml
+++ b/groups.yaml
@@ -39,6 +39,9 @@ interior_temperature:
     - sensor.nursery_temperature
     - sensor.office__josh_temperature
     - sensor.office__tracy_temperature
+    - script.climate_its_ok_out
+    - script.climate_its_hot_outside
+    - script.climate_its_cold_outside
 
 weather:
   name: Weather Forecast

--- a/packages/southern_comfort.yaml
+++ b/packages/southern_comfort.yaml
@@ -16,6 +16,10 @@ script:
           operation_mode: 'auto'
       - service: climate.ecobee_resume_program
         entity_id: climate.home
+      - service: climate.set_fan_mode
+        entity_id: climate.home
+        data:
+          fan_mode: auto
 
   climate_its_hot_outside:
     sequence:
@@ -25,6 +29,10 @@ script:
           operation_mode: 'cool'
           target_temp_low: 68
           target_temp_high: 70
+      - service: climate.set_fan_mode
+        entity_id: climate.home
+        data:
+          fan_mode: 'on'
 
   climate_its_cold_outside:
     sequence:
@@ -34,3 +42,7 @@ script:
           operation_mode: 'heat'
           target_temp_low: 70
           target_temp_high: 72
+      - service: climate.set_fan_mode
+        entity_id: climate.home
+        data:
+          fan_mode: auto

--- a/packages/southern_comfort.yaml
+++ b/packages/southern_comfort.yaml
@@ -4,17 +4,12 @@ input_select:
     initial: OK I GUESS
     options:
       - OK I GUESS
-      - PERFECT
       - HOT OUTSIDE
       - COLD OUTSIDE
 
-automation:
-  - alias: adjust thermostat when it's okay
-    trigger:
-      platform: state
-      entity_id: input_select.exterior_weather
-      to: OK I GUESS
-    action:
+script:
+  climate_its_ok_out:
+    sequence:
       - service: climate.set_operation_mode
         entity_id: climate.home
         data:
@@ -22,50 +17,20 @@ automation:
       - service: climate.ecobee_resume_program
         entity_id: climate.home
 
-  - alias: adjust thermostat when it's ok
-    trigger:
-      platform: state
-      entity_id: input_select.exterior_weather
-      to: OK I GUESS
-    action:
-      - service: climate.set_operation_mode
-        entity_id: climate.home
-        data:
-          operation_mode: 'auto'
-      - service: climate.ecobee_resume_program
-        entity_id: climate.home
-
-  
-  - alias: adjust thermostat when it's hot outside
-    trigger:
-      platform: state
-      entity_id: input_select.exterior_weather
-      to: HOT OUTSIDE
-    action:
-      - service: climate.set_operation_mode
-        entity_id: climate.home
-        data:
-          operation_mode: 'cool'
+  climate_its_hot_outside:
+    sequence:
       - service: climate.set_temperature
-        entity_id: climate.home
         data:
-          operation_mode: auto
+          entity_id: climate.home
+          operation_mode: 'cool'
           target_temp_low: 68
           target_temp_high: 70
 
-  - alias: adjust thermostat when it's cold outside
-    trigger:
-      platform: state
-      entity_id: input_select.exterior_weather
-      to: COLD OUTSIDE
-    action:
-      - service: climate.set_operation_mode
-        entity_id: climate.home
-        data:
-          operation_mode: 'auto'
+  climate_its_cold_outside:
+    sequence:
       - service: climate.set_temperature
         entity_id: climate.home
         data:
-          operation_mode: auto
+          operation_mode: 'heat'
           target_temp_low: 70
           target_temp_high: 72

--- a/packages/southern_comfort.yaml
+++ b/packages/southern_comfort.yaml
@@ -1,14 +1,52 @@
-input_select:
-  exterior_weather:
-    name: How's the day star treating us?
-    initial: OK I GUESS
-    options:
-      - OK I GUESS
-      - HOT OUTSIDE
-      - COLD OUTSIDE
+sensor:
+  - platform: template
+    sensors:
+      subjective_exterior_temperature:
+        friendly_name: "Subjective Exterior Temperature"
+        value_template: |
+          {% set temperature = states.weather.home.attributes.temperature %}
+          {% if temperature > 65 -%}
+          hot
+          {%- elif temperature < 50 -%}
+          cold
+          {%- else -%}
+          ok
+          {%- endif %}
+
+automation:
+  - alias: "Apply southern comfort"
+    # check for the subject temperature to change at all, and stay there for 10 minutes
+    trigger:
+      - platform: state
+        entity_id: sensor.subjective_exterior_temperature
+        to: hot
+        for:
+          minutes: 10
+      - platform: state
+        entity_id: sensor.subjective_exterior_temperature
+        to: cold
+        for:
+          minutes: 10
+      - platform: state
+        entity_id: sensor.subjective_exterior_temperature
+        to: ok
+        for:
+          minutes: 10
+    action:
+      service: script.turn_on
+      entity_id: script.apply_southern_comfort
 
 script:
-  climate_its_ok_out:
+  apply_southern_comfort:
+    sequence:
+      - service: script.turn_on
+        data_template:
+          entity_id: script.climate_its_{{ states.sensor.subjective_exterior_temperature.state }}_outside
+      - service: notify.slack
+        data_template:
+          message: "I do declare, it's {{states.sensor.subjective_exterior_temperature.state}} outside"
+
+  climate_its_ok_outside:
     sequence:
       - service: climate.set_operation_mode
         entity_id: climate.home
@@ -16,33 +54,29 @@ script:
           operation_mode: 'auto'
       - service: climate.ecobee_resume_program
         entity_id: climate.home
-      - service: climate.set_fan_mode
-        entity_id: climate.home
-        data:
-          fan_mode: auto
 
   climate_its_hot_outside:
     sequence:
-      - service: climate.set_temperature
-        data:
-          entity_id: climate.home
-          operation_mode: 'cool'
-          target_temp_low: 68
-          target_temp_high: 70
       - service: climate.set_fan_mode
         entity_id: climate.home
         data:
           fan_mode: 'on'
+      - service: climate.set_temperature
+        entity_id: climate.home
+        data:
+          operation_mode: 'cool'
+          target_temp_low: 68
+          target_temp_high: 70
 
   climate_its_cold_outside:
     sequence:
+      - service: climate.set_fan_mode
+        entity_id: climate.home
+        data:
+          fan_mode: auto
       - service: climate.set_temperature
         entity_id: climate.home
         data:
           operation_mode: 'heat'
           target_temp_low: 70
           target_temp_high: 72
-      - service: climate.set_fan_mode
-        entity_id: climate.home
-        data:
-          fan_mode: auto

--- a/packages/southern_comfort.yaml
+++ b/packages/southern_comfort.yaml
@@ -1,3 +1,11 @@
+################################################################################
+# Southern Comfort
+# keeping things comfortable despite the day star's best efforts, and the
+# apparent lack of smart thermostat developers living in the southeastern US
+#
+# Uses ecobee specific services (climate.ecobee_resume_program)
+################################################################################
+
 sensor:
   - platform: template
     sensors:
@@ -5,7 +13,7 @@ sensor:
         friendly_name: "Subjective Exterior Temperature"
         value_template: |
           {% set temperature = states.weather.home.attributes.temperature %}
-          {% if temperature > 65 -%}
+          {% if temperature > 67 -%}
           hot
           {%- elif temperature < 50 -%}
           cold
@@ -16,6 +24,8 @@ sensor:
 automation:
   - alias: "Apply southern comfort"
     # check for the subject temperature to change at all, and stay there for 10 minutes
+    # `for` requires `to` to be set. `trigger` supports multiple triggers, so add
+    # one per possible value of sensor.subjective_exterior_temperature
     trigger:
       - platform: state
         entity_id: sensor.subjective_exterior_temperature
@@ -37,24 +47,13 @@ automation:
       entity_id: script.apply_southern_comfort
 
 script:
-  apply_southern_comfort:
-    sequence:
-      - service: script.turn_on
-        data_template:
-          entity_id: script.climate_its_{{ states.sensor.subjective_exterior_temperature.state }}_outside
-      - service: notify.slack
-        data_template:
-          message: "I do declare, it's {{states.sensor.subjective_exterior_temperature.state}} outside"
-
+  # use the regular schedule when it's okay out. this is 68-72 on auto, with fan on auto
   climate_its_ok_outside:
     sequence:
-      - service: climate.set_operation_mode
-        entity_id: climate.home
-        data:
-          operation_mode: 'auto'
       - service: climate.ecobee_resume_program
         entity_id: climate.home
 
+  # when it's hot outside, set upper temperature to 70 and set fan to 'on'
   climate_its_hot_outside:
     sequence:
       - service: climate.set_fan_mode
@@ -68,6 +67,7 @@ script:
           target_temp_low: 68
           target_temp_high: 70
 
+  # when it's cold outside, set lower temperature to 70 and set fan to 'auto'
   climate_its_cold_outside:
     sequence:
       - service: climate.set_fan_mode
@@ -80,3 +80,14 @@ script:
           operation_mode: 'heat'
           target_temp_low: 70
           target_temp_high: 72
+
+  # uses subject_exterior_temperature to call one of the climate
+  apply_southern_comfort:
+    sequence:
+      - service: script.turn_on
+        data_template:
+          entity_id: script.climate_its_{{ states.sensor.subjective_exterior_temperature.state }}_outside
+      - service: notify.slack
+        data_template:
+          message: "I do declare, it's {{states.sensor.subjective_exterior_temperature.state}} outside"
+

--- a/packages/southern_comfort.yaml
+++ b/packages/southern_comfort.yaml
@@ -1,0 +1,71 @@
+input_select:
+  exterior_weather:
+    name: How's the day star treating us?
+    initial: OK I GUESS
+    options:
+      - OK I GUESS
+      - PERFECT
+      - HOT OUTSIDE
+      - COLD OUTSIDE
+
+automation:
+  - alias: adjust thermostat when it's okay
+    trigger:
+      platform: state
+      entity_id: input_select.exterior_weather
+      to: OK I GUESS
+    action:
+      - service: climate.set_operation_mode
+        entity_id: climate.home
+        data:
+          operation_mode: 'auto'
+      - service: climate.ecobee_resume_program
+        entity_id: climate.home
+
+  - alias: adjust thermostat when it's ok
+    trigger:
+      platform: state
+      entity_id: input_select.exterior_weather
+      to: OK I GUESS
+    action:
+      - service: climate.set_operation_mode
+        entity_id: climate.home
+        data:
+          operation_mode: 'auto'
+      - service: climate.ecobee_resume_program
+        entity_id: climate.home
+
+  
+  - alias: adjust thermostat when it's hot outside
+    trigger:
+      platform: state
+      entity_id: input_select.exterior_weather
+      to: HOT OUTSIDE
+    action:
+      - service: climate.set_operation_mode
+        entity_id: climate.home
+        data:
+          operation_mode: 'cool'
+      - service: climate.set_temperature
+        entity_id: climate.home
+        data:
+          operation_mode: auto
+          target_temp_low: 68
+          target_temp_high: 70
+
+  - alias: adjust thermostat when it's cold outside
+    trigger:
+      platform: state
+      entity_id: input_select.exterior_weather
+      to: COLD OUTSIDE
+    action:
+      - service: climate.set_operation_mode
+        entity_id: climate.home
+        data:
+          operation_mode: 'auto'
+      - service: climate.set_temperature
+        entity_id: climate.home
+        data:
+          operation_mode: auto
+          target_temp_low: 70
+          target_temp_high: 72


### PR DESCRIPTION
Start with a select_input for what the temperature outside is, and then set the climate based on that.

Eventually, could trigger changes on that select_input based on the actual, real temperature.

This doesn't try to tackle fan mode, which isn't supported yet.

This is work towards https://github.com/technicalpickles/picklehome/issues/40