### PR TITLE
Southern comfort adjustments

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -42,7 +42,7 @@ scene: !include scenes.yaml
 script: !include scripts.yaml
 sleepiq: !include sleepiq.yaml
 sensor:
-  - platform: yr
+  - !include darksky.yaml
 sun:
 switch:
   - !include broadlink.yaml

--- a/darksky.yaml
+++ b/darksky.yaml
@@ -1,0 +1,8 @@
+platform: darksky
+api_key: !secret darksky_api_key
+monitored_conditions:
+- summary
+- icon
+- apparent_temperature
+- cloud_cover
+- precip_type

--- a/packages/southern_comfort.yaml
+++ b/packages/southern_comfort.yaml
@@ -50,8 +50,16 @@ script:
   # use the regular schedule when it's okay out. this is 68-72 on auto, with fan on auto
   climate_its_ok_outside:
     sequence:
-      - service: climate.ecobee_resume_program
+      - service: climate.set_fan_mode
         entity_id: climate.home
+        data:
+          fan_mode: 'auto'
+      - service: climate.set_temperature
+        entity_id: climate.home
+        data:
+          operation_mode: 'auto'
+          target_temp_low: 68
+          target_temp_high: 72
 
   # when it's hot outside, set upper temperature to 70 and set fan to 'on'
   climate_its_hot_outside:

--- a/packages/southern_comfort.yaml
+++ b/packages/southern_comfort.yaml
@@ -12,8 +12,8 @@ sensor:
       subjective_exterior_temperature:
         friendly_name: "Subjective Exterior Temperature"
         value_template: |
-          {% set temperature = states.weather.home.attributes.temperature %}
-          {% if temperature > 67 -%}
+          {% set temperature = states("sensor.dark_sky_apparent_temperature") %}
+          {% if temperature > 65 -%}
           hot
           {%- elif temperature < 50 -%}
           cold
@@ -90,4 +90,3 @@ script:
       - service: notify.slack
         data_template:
           message: "I do declare, it's {{states.sensor.subjective_exterior_temperature.state}} outside"
-

--- a/secrets.yaml.example
+++ b/secrets.yaml.example
@@ -24,3 +24,4 @@ kodi_port: 8080
 fireplace_media: "smb://yourserver/videos/yourvideo.mkv"
 broadlink_host: '127.0.0.1'
 broadlink_mac: 00:00:00:00:00
+darksky_api_key: aaaaaaaaaaaaaaaaaaaaaa


### PR DESCRIPTION
I've definitely had to touch the thermostat a lot less since landing this package. There are still a few times where I need to fiddle, but usually it has to do when it is particularly sunny, humid, rainy, etc. Was telling @jnewland about this, and he suggested using [darksky](https://www.home-assistant.io/components/sensor.darksky)'s apparent temperature.

A few other improvements while I was here:

- update `climate_its_ok_outside` to just set operation mode with a min/max temperature, instead of relying on the ecobee-specific service call that requires setting a schedule
- replace hard-coded numbers with secrets:
  - `southern_comfort_low`
  - `southern_comfort_ideal`
  - `southern_comfort_high`

This should make it easier to drop in the package into another HA config, assuming you set those secrets and make sure `sensor.dark_sky_apparent_temperature` is set.

cc https://github.com/technicalpickles/picklehome/search?q=southern&type=Issues