### PR TITLE
Move from harmony-api to using remote.harmony_hub for switches

### DIFF
--- a/packages/harmony_hub.yaml
+++ b/packages/harmony_hub.yaml
@@ -85,7 +85,3 @@ switch:
         turn_off:
           - service: remote.turn_off
             entity_id: remote.harmony_hub
-      #media_room_tv:
-      #  friendly_name: Super Nintendo
-      #  value_template: >
-      #     {{ states('remote.harmony_hub') }}

--- a/packages/harmony_hub.yaml
+++ b/packages/harmony_hub.yaml
@@ -1,50 +1,91 @@
+media_player:
+  - platform: universal
+    name: Media Room TV
+    children:
+      - media_player.apple_tv_2
+    state_template: >
+      {%- if is_state('remote.harmony_hub', 'off') %}
+        idle
+      {%- else %}
+        {%- if is_state_attr('remote.harmony_hub', 'current_activity', 'Watch Apple TV') %}
+          {{ states('media_player.apple_tv_2') }}
+        {%- endif %}
+      {%- endif %}
+    commands:
+      turn_off:
+        service: remote.turn_off
+        entity_id: remote.harmony_hub
+      turn_on:
+        service: remote.turn_on
+        entity_id: remote.harmony_hub
 switch:
-  - platform: mqtt
-    name: "Media Room TV"
-    state_topic: "harmony-api/hubs/harmony-hub/state"
-    command_topic: "harmony-api/hubs/harmony-hub/activities/watch-tv/command"
-    qos: 0
-    optimistic: true
-    payload_on: "on"
-    payload_off: "off"
-  - platform: mqtt
-    name: "DirecTV"
-    state_topic: "harmony-api/hubs/harmony-hub/activities/watch-tv/state"
-    command_topic: "harmony-api/hubs/harmony-hub/activities/watch-tv/command"
-    qos: 0
-    optimistic: true
-    payload_on: "on"
-    payload_off: "off"
-  - platform: mqtt
-    name: "Apple TV"
-    state_topic: "harmony-api/hubs/harmony-hub/activities/watch-apple-tv/state"
-    command_topic: "harmony-api/hubs/harmony-hub/activities/watch-apple-tv/command"
-    qos: 0
-    optimistic: true
-    payload_on: "on"
-    payload_off: "off"
-  - platform: mqtt
-    name: "Smart TV"
-    state_topic: "harmony-api/hubs/harmony-hub/activities/watch-smart-tv/state"
-    command_topic: "harmony-api/hubs/harmony-hub/activities/watch-smart-tv/command"
-    qos: 0
-    optimistic: true
-    payload_on: "on"
-    payload_off: "off"
-  - platform: mqtt
-    name: "Super Nintendo"
-    state_topic: "harmony-api/hubs/harmony-hub/activities/play-super-nintendo/state"
-    command_topic: "harmony-api/hubs/harmony-hub/activities/play-super-nintendo/command"
-    qos: 0
-    optimistic: true
-    payload_on: "on"
-    payload_off: "off"
-  - platform: mqtt
-    name: "Media Room Music"
-    state_topic: "harmony-api/hubs/harmony-hub/activities/listen-to-music/state"
-    command_topic: "harmony-api/hubs/harmony-hub/activities/listen-to-music/command"
-    qos: 0
-    optimistic: true
-    payload_on: "on"
-    payload_off: "off"
-
+  - platform: template
+    switches:
+      apple_tv:
+        friendly_name: Apple TV
+        value_template: >
+           {%- if is_state_attr('remote.harmony_hub', 'current_activity', 'Watch Apple TV') %}
+             on
+           {%- else %}
+             off
+           {%- endif %}
+        turn_on:
+          - service: remote.turn_on
+            entity_id: remote.harmony_hub
+            data:
+              activity: Watch Apple TV
+        turn_off:
+          - service: remote.turn_off
+            entity_id: remote.harmony_hub
+      directv:
+        friendly_name: DirecTV
+        value_template: >
+           {%- if is_state_attr('remote.harmony_hub', 'current_activity', 'Watch TV') %}
+             on
+           {%- else %}
+             off
+           {%- endif %}
+        turn_on:
+          - service: remote.turn_on
+            entity_id: remote.harmony_hub
+            data:
+              activity: Watch TV
+        turn_off:
+          - service: remote.turn_off
+            entity_id: remote.harmony_hub
+      smart_tv:
+        friendly_name: Smart TV
+        value_template: >
+           {%- if is_state_attr('remote.harmony_hub', 'current_activity', 'Watch Smart TV') %}
+             on
+           {%- else %}
+             off
+           {%- endif %}
+        turn_on:
+          - service: remote.turn_on
+            entity_id: remote.harmony_hub
+            data:
+              activity: Watch Smart TV
+        turn_off:
+          - service: remote.turn_off
+            entity_id: remote.harmony_hub
+      super_nintendo:
+        friendly_name: Super Nintendo
+        value_template: >
+           {%- if is_state_attr('remote.harmony_hub', 'current_activity', 'Play Super Nintendo') %}
+             on
+           {%- else %}
+             off
+           {%- endif %}
+        turn_on:
+          - service: remote.turn_on
+            entity_id: remote.harmony_hub
+            data:
+              activity: Play Super Nintendo
+        turn_off:
+          - service: remote.turn_off
+            entity_id: remote.harmony_hub
+      #media_room_tv:
+      #  friendly_name: Super Nintendo
+      #  value_template: >
+      #     {{ states('remote.harmony_hub') }}


### PR DESCRIPTION
The media_player is still under development, but the switches seem to work well.