### PR TITLE
Remove extra_html workaround for defaulting to lovelace

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -20,8 +20,7 @@ config:
 discovery:
 frontend:
   javascript_version: latest
-  extra_html_url:
-    - /local/lovelace.html
+  extra_html_url: []
 history:
 http:
   api_password: !secret http_api_password

--- a/www/lovelace.html
+++ b/www/lovelace.html
@@ -1,7 +1,0 @@
-<script>
-    var hack_element = document.querySelector('home-assistant').shadowRoot.querySelector('home-assistant-main').shadowRoot.querySelector('ha-sidebar').shadowRoot.querySelector('paper-icon-item[data-panel="states"]');
-    if (hack_element) {
-        hack_element.setAttribute("data-panel", "lovelace");
-        localStorage.defaultPage = 'lovelace';
-    }
-</script>


### PR DESCRIPTION
Now there is a cookie thing for doing this.