### PR TITLE
Automate turning off attic fan after lights have been off in attic

### DIFF
--- a/packages/attic_fan.yaml
+++ b/packages/attic_fan.yaml
@@ -1,25 +1,15 @@
 automation:
-#  - alias: Turn off attic fan when unoccupied
-#    trigger:
-#      - platform: state
-#        entity_id: binary_sensor.josh_office_occupancy
-#        to: 'off'
-#        for:
-#          minutes: 10
-#    action:
-#      service: switch.turn_off
-#      entity_id: switch.attic_fan
-#  - alias: Turn on attic fan when occupied and hot out
-#    trigger:
-#      - platform: numeric_state
-#        entity_id: sensor.josh_office_temperature
-#        above: 72
-#        for:
-#          minutes: 10
-#    condition:
-#      - platform: state
-#        entity_id: binary_sensor.josh_office_occupancy
-#        state: 'off'
-#    action:
-#      service: switch.turn_on
-#      entity_id: switch.attic_fan
+  - alias: Attic Fan automatic off with lights
+    trigger:
+      - platform: state
+        entity_id: light.josh_desk
+        to: 'off'
+        for:
+          minutes: 10
+    condition:
+      condition: state
+      entity_id: switch.attic_fan
+      state: 'on'
+    action:
+      service: switch.turn_off
+      entity_id: switch.attic_fan

--- a/ui-lovelace.yaml
+++ b/ui-lovelace.yaml
@@ -123,6 +123,12 @@ views:
           - media_player.fireplace
           - input_select.fireplace_tv_source_selector
           - media_player.fireplace_kodi
+      - title: Attic Fan
+        type: entities
+        show_header_toggle: false
+        entities:
+          - automation.attic_fan_automatic_off_with_lights
+          - switch.attic_fan
 
   - title: Interior Temperature
     id: interior-temperature


### PR DESCRIPTION
These lights are controlled by a Hue Motion Sensor, such that when it is idle
for 5 minutes, it turns off. So, when that happens and it stays off
another 10 minutes, the fan turns on too.

Closes https://github.com/technicalpickles/picklehome/issues/52